### PR TITLE
feat: add startup pitch calibration mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The GUI provides:
 
 ## Parameters (excerpt)
 - **I/O**: `image_topic`, `use_color_output`, `publish_image_with_lines`
-- **Calibration**: `camera_info_topic` (string), `camera_height_meters` (double; default 0.2), `landmark_distance_meters` (double; default 0.7), `calib_timeout_sec` (double; default 60.0)
+- **Calibration**: `camera_info_topic` (string), `camera_height_meters` (double; default 0.2), `landmark_distance_meters` (double; default 0.59), `calib_timeout_sec` (double; default 60.0; set 0 to disable timeout and keep calibrating continuously)
 - **Pre-processing**: `grayscale`, `blur_ksize`, `blur_sigma`, `roi`, `downscale`
 - **Canny Edge**: `canny_low`, `canny_high`, `canny_aperture`, `canny_L2gradient`
 - **Hough Transform**: `hough_type`, `rho`, `theta_deg`, `threshold`, `min_line_length`, `max_line_gap`

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A ROS 2 C++ node that detects straight lines using Canny + Hough transform and p
 - **Startup Calibration**: Estimates camera pitch using a known landmark distance, then switches to normal publishing
 - **Low Latency**: Never drops the frame being processed; subscription queue keeps only the latest frame (QoS depth = 1)
 - **Flexible Parameters**: Dynamically tune Canny/Hough, pre-processing, and visualization parameters
-- **Multiple Outputs**: Publishes detection results as arrays, visualization images, and RViz markers
+- **Multiple Outputs**: Publishes detection results as arrays and visualization images
 - **Parameter GUI**: Interactive Python GUI for real-time parameter adjustment with live image feed
 - **Timing Logs**: Outputs per-frame processing time using `steady_clock` at INFO level
 
@@ -96,16 +96,16 @@ The GUI provides:
 - **Output**:
   - `/image_with_lines` (`sensor_msgs/msg/Image`) — visualization with detected lines overlaid
   - `/lines` (`std_msgs/msg/Float32MultiArray`) — line segments as flat `[x1, y1, x2, y2, ...]` array  
-  - `/markers` (`visualization_msgs/msg/MarkerArray`) — RViz visualization markers
+
 
 ## Parameters (excerpt)
-- **I/O**: `image_topic`, `use_color_output`, `publish_image_with_lines`
+- **I/O**: `image_topic`, `publish_image_with_lines`, `show_edges`
 - **Calibration**: `camera_info_topic` (string), `camera_height_meters` (double; default 0.2), `landmark_distance_meters` (double; default 0.59), `calib_timeout_sec` (double; default 60.0; set 0 to disable timeout and keep calibrating continuously), `calib_roi` (int[4]; default [200,150,240,180]), HSV thresholds (`calib_hsv_s_max`=16, `calib_hsv_v_min`=100, `calib_hsv_v_max`=168)
-- **Pre-processing**: `grayscale`, `blur_ksize`, `blur_sigma`, `roi`, `downscale`
+- **Pre-processing**: `blur_ksize`, `blur_sigma`, `roi`
 - **Canny Edge**: `canny_low`, `canny_high`, `canny_aperture`, `canny_L2gradient`
 - **Hough Transform**: `hough_type`, `rho`, `theta_deg`, `threshold`, `min_line_length`, `max_line_gap`
 - **HSV Mask**: `use_hsv_mask`, `hsv_lower_*`, `hsv_upper_*`, morphology parameters
-- **Visualization**: `draw_color_bgr`, `draw_thickness`, `publish_markers`
+- **Visualization**: `draw_color_bgr`, `draw_thickness`
 
 See [doc/DESIGN.md](doc/DESIGN.md) for complete parameter documentation.
 

--- a/README.md
+++ b/README.md
@@ -63,12 +63,31 @@ cd /path/to/etrobo_line_detector
 python3 scripts/line_detector_gui.py
 ```
 
+### Calibration Tuning
+For gray disk detection issues during calibration, use the GUI's **Calibration** section:
+
+```bash
+# Start node with continuous calibration (no timeout)
+ros2 run etrobo_line_detector etrobo_line_detector \
+  --ros-args \
+  -p publish_image_with_lines:=true \
+  -p calib_timeout_sec:=0.0
+
+# Launch GUI and adjust:
+# - calib_hsv_v_min/max: For gray brightness range
+# - calib_hsv_s_max: For color saturation threshold  
+# - calib_min_area: For minimum disk size
+# - calib_roi_*: To focus detection on specific region
+python3 scripts/line_detector_gui.py
+```
+
 The GUI provides:
 - **Live Image Display**: Real-time visualization of detection results
-- **Organized Parameters**: 8 categories of parameters with intuitive controls
+- **Organized Parameters**: 9 categories of parameters with intuitive controls
 - **Interactive Widgets**: Sliders, checkboxes, dropdowns for different parameter types
 - **Real-time Updates**: Changes apply immediately to the running node
 - **Anti-flicker**: Smooth 30fps display with optimized rendering
+- **Calibration Support**: Interactive tuning of gray disk detection parameters during calibration
 
 ## Topics
 - **Input**: `~image` (`sensor_msgs/msg/Image`) — source camera image
@@ -100,7 +119,7 @@ See [doc/DESIGN.md](doc/DESIGN.md) for complete parameter documentation.
   - If calibration times out (`calib_timeout_sec`), the node proceeds with a 0 rad pitch.
 
 ## GUI Parameter Categories
-The Python GUI organizes parameters into 8 intuitive sections:
+The Python GUI organizes parameters into 9 intuitive sections:
 1. **I/O Settings** — Input/output configuration
 2. **Pre-processing** — Image preparation (ROI, blur, scaling)
 3. **Canny Edge** — Edge detection parameters
@@ -108,7 +127,8 @@ The Python GUI organizes parameters into 8 intuitive sections:
 5. **HSV Mask** — Color-based filtering for black lines
 6. **Edge Closing** — Morphological edge enhancement
 7. **Temporal Smoothing** — Multi-frame line tracking
-8. **Visualization** — Drawing and output options
+8. **Calibration** — Camera pitch estimation and gray disk detection settings
+9. **Visualization** — Drawing and output options
 
 ## License
 This project follows the repository’s license policy.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A ROS 2 C++ node that detects straight lines using Canny + Hough transform and publishes both the detection results and a visualization image. Includes a Python GUI tool for real-time parameter tuning.
 
 ## Features
-- **Line Detection**: Canny edge detection + Hough transform with temporal smoothing
+- **Line Detection**: Canny edge detection + Hough transform
 - **Startup Calibration**: Estimates camera pitch using a known landmark distance, then switches to normal publishing
 - **Low Latency**: Never drops the frame being processed; subscription queue keeps only the latest frame (QoS depth = 1)
 - **Flexible Parameters**: Dynamically tune Canny/Hough, pre-processing, and visualization parameters
@@ -105,31 +105,27 @@ The GUI provides:
 - **Canny Edge**: `canny_low`, `canny_high`, `canny_aperture`, `canny_L2gradient`
 - **Hough Transform**: `hough_type`, `rho`, `theta_deg`, `threshold`, `min_line_length`, `max_line_gap`
 - **HSV Mask**: `use_hsv_mask`, `hsv_lower_*`, `hsv_upper_*`, morphology parameters
-- **Edge Closing**: `use_edge_close`, `edge_close_kernel`, `edge_close_iter`
-- **Temporal Smoothing**: `enable_temporal_smoothing`, `ema_alpha`, tracking parameters
 - **Visualization**: `draw_color_bgr`, `draw_thickness`, `publish_markers`
 
 See [doc/DESIGN.md](doc/DESIGN.md) for complete parameter documentation.
 
 ## Startup Calibration
 - On startup the node enters CalibratePitch state:
-  - Enables temporal smoothing, does not publish the `lines` topic.
+  - Does not publish the `lines` topic.
   - Detects the gray start-circle and collects several detections.
   - Computes camera pitch using camera intrinsics, known camera height, and known landmark distance.
-  - Transitions to Ready, disables temporal smoothing, and starts publishing `lines`.
+  - Transitions to Ready and starts publishing `lines`.
   - If calibration times out (`calib_timeout_sec`), the node proceeds with a 0 rad pitch.
 
 ## GUI Parameter Categories
-The Python GUI organizes parameters into 9 intuitive sections:
+The Python GUI organizes parameters into 7 intuitive sections:
 1. **I/O Settings** — Input/output configuration
 2. **Pre-processing** — Image preparation (ROI, blur, scaling)
 3. **Canny Edge** — Edge detection parameters
 4. **Hough Transform** — Line detection settings
 5. **HSV Mask** — Color-based filtering for black lines
-6. **Edge Closing** — Morphological edge enhancement
-7. **Temporal Smoothing** — Multi-frame line tracking
-8. **Calibration** — Camera pitch estimation and gray disk detection settings
-9. **Visualization** — Drawing and output options
+6. **Calibration** — Camera pitch estimation and gray disk detection settings
+7. **Visualization** — Drawing and output options
 
 ## License
 This project follows the repository’s license policy.

--- a/README.md
+++ b/README.md
@@ -74,10 +74,11 @@ ros2 run etrobo_line_detector etrobo_line_detector \
   -p calib_timeout_sec:=0.0
 
 # Launch GUI and adjust:
-# - calib_hsv_v_min/max: For gray brightness range
-# - calib_hsv_s_max: For color saturation threshold  
-# - calib_min_area: For minimum disk size
-# - calib_roi_*: To focus detection on specific region
+# - calib_hsv_s_max (default=16): Very low saturation for gray objects
+# - calib_hsv_v_min (default=100): Minimum brightness for detection
+# - calib_hsv_v_max (default=168): Maximum brightness threshold
+# - calib_roi_* (default=200,150,240,180): Focus detection region
+# - HSV mask visualization appears in top-right corner during calibration
 python3 scripts/line_detector_gui.py
 ```
 
@@ -87,7 +88,7 @@ The GUI provides:
 - **Interactive Widgets**: Sliders, checkboxes, dropdowns for different parameter types
 - **Real-time Updates**: Changes apply immediately to the running node
 - **Anti-flicker**: Smooth 30fps display with optimized rendering
-- **Calibration Support**: Interactive tuning of gray disk detection parameters during calibration
+- **Calibration Support**: Interactive tuning of gray disk detection parameters during calibration with HSV mask visualization
 
 ## Topics
 - **Input**: `~image` (`sensor_msgs/msg/Image`) — source camera image
@@ -99,7 +100,7 @@ The GUI provides:
 
 ## Parameters (excerpt)
 - **I/O**: `image_topic`, `use_color_output`, `publish_image_with_lines`
-- **Calibration**: `camera_info_topic` (string), `camera_height_meters` (double; default 0.2), `landmark_distance_meters` (double; default 0.59), `calib_timeout_sec` (double; default 60.0; set 0 to disable timeout and keep calibrating continuously)
+- **Calibration**: `camera_info_topic` (string), `camera_height_meters` (double; default 0.2), `landmark_distance_meters` (double; default 0.59), `calib_timeout_sec` (double; default 60.0; set 0 to disable timeout and keep calibrating continuously), `calib_roi` (int[4]; default [200,150,240,180]), HSV thresholds (`calib_hsv_s_max`=16, `calib_hsv_v_min`=100, `calib_hsv_v_max`=168)
 - **Pre-processing**: `grayscale`, `blur_ksize`, `blur_sigma`, `roi`, `downscale`
 - **Canny Edge**: `canny_low`, `canny_high`, `canny_aperture`, `canny_L2gradient`
 - **Hough Transform**: `hough_type`, `rho`, `theta_deg`, `threshold`, `min_line_length`, `max_line_gap`

--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -17,6 +17,19 @@
   - `calib_timeout_sec` (double; default: `60.0`; `0` disables timeout and keeps calibration running)
   - Uses an internal buffer of landmark detections (median of ~10 samples) to robustly estimate pitch.
 
+## Calibration Parameters (Gray Circle Detection)
+- `calib_roi` (int[4]; default: `[200, 150, 240, 180]`): ROI for gray circle detection `[x, y, w, h]`
+- HSV thresholds for gray circle detection:
+  - `calib_hsv_s_max` (int; default: `16`): maximum saturation (very low for gray objects)
+  - `calib_hsv_v_min` (int; default: `100`): minimum brightness value
+  - `calib_hsv_v_max` (int; default: `168`): maximum brightness value
+- Circle detection constraints:
+  - `calib_min_area` (int; default: `80`): minimum contour area in pixels
+  - `calib_min_major_px` (int; default: `8`): minimum ellipse major axis length
+  - `calib_max_major_ratio` (double; default: `0.65`): maximum major axis as fraction of image size
+  - `calib_fill_min` (double; default: `0.25`): minimum fill ratio (mask pixels / ellipse area)
+- Debug visualization: HSV mask displayed in top-right corner during calibration
+
 ## Topics
 - Input
   - `~image` (`sensor_msgs/msg/Image`): subscribe via `image_transport` (raw recommended)
@@ -57,6 +70,7 @@
   - `publish_image_with_lines` (bool; default: `false`): publish the overlay image.
     When `false`, the node does not create the image publisher and skips all
     visualization rendering to reduce CPU load.
+  - During calibration: displays HSV mask (160x120px) in top-right corner with semi-transparent background
 
 ## HSV Mask (optional)
 - `use_hsv_mask` (bool; default: `true`): enable HSV masking after Canny to isolate the black center line.

--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -13,8 +13,8 @@
 - Parameters:
   - `camera_info_topic` (string; default: `camera_info`)
   - `camera_height_meters` (double; default: `0.2`)
-  - `landmark_distance_meters` (double; default: `0.7`)
-  - `calib_timeout_sec` (double; default: `60.0`)
+  - `landmark_distance_meters` (double; default: `0.59`)
+  - `calib_timeout_sec` (double; default: `60.0`; `0` disables timeout and keeps calibration running)
   - Uses an internal buffer of landmark detections (median of ~10 samples) to robustly estimate pitch.
 
 ## Topics

--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -54,7 +54,7 @@
   - `blur_ksize` (int; default: `5`) odd values only
   - `blur_sigma` (double; default: `1.5`)
   - `roi` (int[4]; default: `[-1, -1, -1, -1]`) `[x, y, w, h]` (disabled when -1)
-  - `downscale` (double; default: `1.0`) `> 0`; 1.0 disables downscaling
+
 - Canny
   - `canny_low` (int; default: `40`), `canny_high` (int; default: `120`)
   - `canny_aperture` (int; default: `3`) allowed: 3, 5, 7
@@ -82,14 +82,14 @@
 
 ## Processing Flow
 1. Convert the received image to `cv::Mat` via `cv_bridge`.
-2. Apply ROI cropping → downscale (`downscale`).
+2. Apply ROI cropping.
 3. Convert to grayscale if needed → apply GaussianBlur.
 4. Run Canny edge detection.
    - If enabled, apply HSV mask to the Canny edges.
 5. Run Hough transform
    - `probabilistic`: use `cv::HoughLinesP` to obtain segments (x1, y1, x2, y2)
    - `standard`: use `cv::HoughLines` to obtain (rho, theta), then extend to image borders to form segments
-6. Invert ROI/downscale to restore coordinates to the original scale.
+6. Restore ROI coordinates to the original scale.
 7. Draw overlays → publish `image_with_lines`, and publish `lines` and `markers`.
 
 ### Calibration math (summary)
@@ -112,7 +112,7 @@
 ## Error Handling
 - Invalid ROI is disabled with a WARN log.
 - Unsupported encodings are converted to BGR/mono if possible; otherwise log WARN and skip the frame.
-- Coerce `downscale <= 0` to `1.0`.
+
 - Reject out-of-range parameters for Canny/Hough at update time.
 
 ## Dependencies

--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -48,9 +48,9 @@
 ## Parameters
 - I/O
   - `image_topic` (string; default: `image`): subscription topic name (also remappable)
-  - `use_color_output` (bool; default: `true`): publish output image as BGR8
+  - `publish_image_with_lines` (bool; default: `false`): enable image output publisher
+  - `show_edges` (bool; default: `false`): display edge image instead of original for debugging
 - Pre-processing
-  - `grayscale` (bool; default: `true`)
   - `blur_ksize` (int; default: `5`) odd values only
   - `blur_sigma` (double; default: `1.5`)
   - `roi` (int[4]; default: `[-1, -1, -1, -1]`) `[x, y, w, h]` (disabled when -1)
@@ -67,19 +67,16 @@
 - Visualization
   - `draw_color_bgr` (int[3]; default: `[0, 255, 0]`), `draw_thickness` (int; default: `2`)
   - `publish_markers` (bool; default: `true`)
-  - `publish_image_with_lines` (bool; default: `false`): publish the overlay image.
-    When `false`, the node does not create the image publisher and skips all
-    visualization rendering to reduce CPU load.
   - During calibration: displays HSV mask (160x120px) in top-right corner with semi-transparent background
 
 ## HSV Mask (optional)
 - `use_hsv_mask` (bool; default: `true`): enable HSV masking after Canny to isolate the black center line.
 - Thresholds:
   - `hsv_lower_h` (int; default: `0`), `hsv_lower_s` (int; default: `0`), `hsv_lower_v` (int; default: `0`)
-  - `hsv_upper_h` (int; default: `180`), `hsv_upper_s` (int; default: `120`), `hsv_upper_v` (int; default: `150`)
+  - `hsv_upper_h` (int; default: `180`), `hsv_upper_s` (int; default: `40`), `hsv_upper_v` (int; default: `148`)
 - Morphology:
   - `hsv_dilate_kernel` (int; default: `3`): odd kernel size.
-  - `hsv_dilate_iter` (int; default: `1`): dilation iterations (0 to disable).
+  - `hsv_dilate_iter` (int; default: `2`): dilation iterations (0 to disable).
 
 
 

--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -37,7 +37,7 @@
 - Output
   - `~image_with_lines` (`sensor_msgs/msg/Image`): debug image with detected lines overlaid (BGR8)
   - `~lines` (`std_msgs/msg/Float32MultiArray`): detected line segments, each as `[x1, y1, x2, y2]` in a flat array
-  - `~markers` (`visualization_msgs/msg/MarkerArray`): optional RViz markers for lines (controlled by a parameter)
+
 
 ## QoS and Latency Optimization
 - Subscription QoS: `rclcpp::SensorDataQoS().keep_last(1).best_effort().durability_volatile()`
@@ -66,7 +66,7 @@
   - standard: `min_theta_deg` (double; `0`), `max_theta_deg` (double; `180`)
 - Visualization
   - `draw_color_bgr` (int[3]; default: `[0, 255, 0]`), `draw_thickness` (int; default: `2`)
-  - `publish_markers` (bool; default: `true`)
+
   - During calibration: displays HSV mask (160x120px) in top-right corner with semi-transparent background
 
 ## HSV Mask (optional)
@@ -90,7 +90,7 @@
    - `probabilistic`: use `cv::HoughLinesP` to obtain segments (x1, y1, x2, y2)
    - `standard`: use `cv::HoughLines` to obtain (rho, theta), then extend to image borders to form segments
 6. Restore ROI coordinates to the original scale.
-7. Draw overlays → publish `image_with_lines`, and publish `lines` and `markers`.
+7. Draw overlays → publish `image_with_lines` and `lines`.
 
 ### Calibration math (summary)
 - Let `v` be the median image row of the gray circle center (pixels), `fy, cy` from camera intrinsics, `u = (v - cy)/fy`.

--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -8,8 +8,8 @@
 
 ## Startup Calibration
 - States:
-  - `CalibratePitch` (initial): enable temporal smoothing; do not publish `~lines`; estimate camera pitch from a gray circle at a known ground distance using `~camera_info` intrinsics.
-  - `Ready`: disable temporal smoothing; publish `~lines` and `~markers` normally.
+  - `CalibratePitch` (initial): do not publish `~lines`; estimate camera pitch from a gray circle at a known ground distance using `~camera_info` intrinsics.
+  - `Ready`: publish `~lines` and `~markers` normally.
 - Parameters:
   - `camera_info_topic` (string; default: `camera_info`)
   - `camera_height_meters` (double; default: `0.2`)
@@ -81,29 +81,15 @@
   - `hsv_dilate_kernel` (int; default: `3`): odd kernel size.
   - `hsv_dilate_iter` (int; default: `1`): dilation iterations (0 to disable).
 
-## Edge Closing (optional)
-- `use_edge_close` (bool; default: `true`): apply morphological closing on edges to reduce fragmentation.
-- `edge_close_kernel` (int; default: `3`): odd kernel size for rectangular structuring element.
-- `edge_close_iter` (int; default: `1`): number of closing iterations (0 to disable).
 
-## Temporal Smoothing (optional)
-- `enable_temporal_smoothing` (bool; default: `true`): publish temporally smoothed line segments.
-- `ema_alpha` (double; default: `0.5`): EMA factor for endpoints; closer to 1.0 trusts the current frame more.
-- `match_max_px` (int; default: `20`): maximum sum of endpoint distances (with best endpoint pairing) to consider a match.
-- `match_max_angle_deg` (double; default: `10.0`): maximum angle difference between track and detection.
-- `min_age_to_publish` (int; default: `2`): minimum matched frames before a track is published.
-- `max_missed` (int; default: `3`): maximum consecutive frames a track can miss before removal.
-
-Algorithm: per frame, greedily match detections to existing tracks using endpoint distance and angle thresholds. Update matched tracks via EMA on endpoints; create new tracks for unmatched detections; age and prune stale tracks. Publish tracks whose age ≥ `min_age_to_publish` (fallback to raw detections if no stable tracks exist in a frame).
 
 ## Processing Flow
 1. Convert the received image to `cv::Mat` via `cv_bridge`.
 2. Apply ROI cropping → downscale (`downscale`).
 3. Convert to grayscale if needed → apply GaussianBlur.
 4. Run Canny edge detection.
-   - If enabled, apply HSV mask to the Canny edges, then optional edge closing (morphological close) before Hough.
+   - If enabled, apply HSV mask to the Canny edges.
 5. Run Hough transform
-6. If temporal smoothing is enabled, match detections to existing tracks and publish smoothed segments (otherwise publish raw detections).
    - `probabilistic`: use `cv::HoughLinesP` to obtain segments (x1, y1, x2, y2)
    - `standard`: use `cv::HoughLines` to obtain (rho, theta), then extend to image borders to form segments
 6. Invert ROI/downscale to restore coordinates to the original scale.

--- a/scripts/line_detector_gui.py
+++ b/scripts/line_detector_gui.py
@@ -154,7 +154,6 @@ class LineDetectorParameterGUI:
                 "publish_image_with_lines": {"type": "bool", "default": False}
             },
             "Pre-processing": {
-                "grayscale": {"type": "bool", "default": True},
                 "blur_ksize": {"type": "int", "default": 5, "min": 1, "max": 21, "step": 2},
                 "blur_sigma": {"type": "double", "default": 1.5, "min": 0.1, "max": 5.0},
                 "downscale": {"type": "double", "default": 1.0, "min": 0.1, "max": 2.0},

--- a/scripts/line_detector_gui.py
+++ b/scripts/line_detector_gui.py
@@ -175,10 +175,10 @@ class LineDetectorParameterGUI:
                 "hsv_lower_s": {"type": "int", "default": 0, "min": 0, "max": 255},
                 "hsv_lower_v": {"type": "int", "default": 0, "min": 0, "max": 255},
                 "hsv_upper_h": {"type": "int", "default": 180, "min": 0, "max": 180},
-                "hsv_upper_s": {"type": "int", "default": 120, "min": 0, "max": 255},
-                "hsv_upper_v": {"type": "int", "default": 150, "min": 0, "max": 255},
+                "hsv_upper_s": {"type": "int", "default": 40, "min": 0, "max": 255},
+                "hsv_upper_v": {"type": "int", "default": 148, "min": 0, "max": 255},
                 "hsv_dilate_kernel": {"type": "int", "default": 3, "min": 1, "max": 21, "step": 2},
-                "hsv_dilate_iter": {"type": "int", "default": 1, "min": 0, "max": 10}
+                "hsv_dilate_iter": {"type": "int", "default": 2, "min": 0, "max": 10}
             },
             "Hough Transform": {
                 "hough_type": {"type": "choice", "default": "probabilistic",

--- a/scripts/line_detector_gui.py
+++ b/scripts/line_detector_gui.py
@@ -151,7 +151,6 @@ class LineDetectorParameterGUI:
         self.parameter_definitions = {
             "I/O Settings": {
                 "image_topic": {"type": "string", "default": "image"},
-                "use_color_output": {"type": "bool", "default": True},
                 "publish_image_with_lines": {"type": "bool", "default": False}
             },
             "Pre-processing": {

--- a/scripts/line_detector_gui.py
+++ b/scripts/line_detector_gui.py
@@ -151,7 +151,8 @@ class LineDetectorParameterGUI:
         self.parameter_definitions = {
             "I/O Settings": {
                 "image_topic": {"type": "string", "default": "image"},
-                "publish_image_with_lines": {"type": "bool", "default": False}
+                "publish_image_with_lines": {"type": "bool", "default": False},
+                "show_edges": {"type": "bool", "default": False}
             },
             "Pre-processing": {
                 "blur_ksize": {"type": "int", "default": 5, "min": 1, "max": 21, "step": 2},

--- a/scripts/line_detector_gui.py
+++ b/scripts/line_detector_gui.py
@@ -209,7 +209,7 @@ class LineDetectorParameterGUI:
             },
             "Visualization": {
                 "draw_thickness": {"type": "int", "default": 2, "min": 1, "max": 10},
-                "publish_markers": {"type": "bool", "default": True}
+
             }
         }
 

--- a/scripts/line_detector_gui.py
+++ b/scripts/line_detector_gui.py
@@ -168,17 +168,6 @@ class LineDetectorParameterGUI:
                 "canny_aperture": {"type": "choice", "default": 3, "choices": [3, 5, 7]},
                 "canny_L2gradient": {"type": "bool", "default": False}
             },
-            "Hough Transform": {
-                "hough_type": {"type": "choice", "default": "probabilistic",
-                               "choices": ["probabilistic", "standard"]},
-                "rho": {"type": "double", "default": 1.0, "min": 0.1, "max": 5.0},
-                "theta_deg": {"type": "double", "default": 1.0, "min": 0.1, "max": 5.0},
-                "threshold": {"type": "int", "default": 50, "min": 1, "max": 200},
-                "min_line_length": {"type": "double", "default": 30.0, "min": 1.0, "max": 200.0},
-                "max_line_gap": {"type": "double", "default": 10.0, "min": 1.0, "max": 100.0},
-                "min_theta_deg": {"type": "double", "default": 0.0, "min": 0.0, "max": 180.0},
-                "max_theta_deg": {"type": "double", "default": 180.0, "min": 0.0, "max": 180.0}
-            },
             "HSV Mask": {
                 "use_hsv_mask": {"type": "bool", "default": True},
                 "hsv_lower_h": {"type": "int", "default": 0, "min": 0, "max": 180},
@@ -189,6 +178,17 @@ class LineDetectorParameterGUI:
                 "hsv_upper_v": {"type": "int", "default": 150, "min": 0, "max": 255},
                 "hsv_dilate_kernel": {"type": "int", "default": 3, "min": 1, "max": 21, "step": 2},
                 "hsv_dilate_iter": {"type": "int", "default": 1, "min": 0, "max": 10}
+            },
+            "Hough Transform": {
+                "hough_type": {"type": "choice", "default": "probabilistic",
+                               "choices": ["probabilistic", "standard"]},
+                "rho": {"type": "double", "default": 1.0, "min": 0.1, "max": 5.0},
+                "theta_deg": {"type": "double", "default": 1.0, "min": 0.1, "max": 5.0},
+                "threshold": {"type": "int", "default": 50, "min": 1, "max": 200},
+                "min_line_length": {"type": "double", "default": 30.0, "min": 1.0, "max": 200.0},
+                "max_line_gap": {"type": "double", "default": 10.0, "min": 1.0, "max": 100.0},
+                "min_theta_deg": {"type": "double", "default": 0.0, "min": 0.0, "max": 180.0},
+                "max_theta_deg": {"type": "double", "default": 180.0, "min": 0.0, "max": 180.0}
             },
             "Calibration": {
                 "camera_height_meters": {"type": "double", "default": 0.2, "min": 0.05, "max": 1.0},

--- a/scripts/line_detector_gui.py
+++ b/scripts/line_detector_gui.py
@@ -209,17 +209,17 @@ class LineDetectorParameterGUI:
                 "camera_height_meters": {"type": "double", "default": 0.2, "min": 0.05, "max": 1.0},
                 "landmark_distance_meters": {"type": "double", "default": 0.59, "min": 0.1, "max": 2.0},
                 "calib_timeout_sec": {"type": "double", "default": 60.0, "min": 0.0, "max": 300.0},
-                "calib_hsv_s_max": {"type": "int", "default": 60, "min": 0, "max": 255},
-                "calib_hsv_v_min": {"type": "int", "default": 80, "min": 0, "max": 255},
+                "calib_hsv_s_max": {"type": "int", "default": 16, "min": 0, "max": 255},
+                "calib_hsv_v_min": {"type": "int", "default": 100, "min": 0, "max": 255},
                 "calib_hsv_v_max": {"type": "int", "default": 168, "min": 0, "max": 255},
                 "calib_min_area": {"type": "int", "default": 80, "min": 10, "max": 1000},
                 "calib_min_major_px": {"type": "int", "default": 8, "min": 1, "max": 100},
                 "calib_max_major_ratio": {"type": "double", "default": 0.65, "min": 0.1, "max": 1.0},
                 "calib_fill_min": {"type": "double", "default": 0.25, "min": 0.0, "max": 1.0},
-                "calib_roi_x": {"type": "int", "default": -1, "min": -1, "max": 1920},
-                "calib_roi_y": {"type": "int", "default": -1, "min": -1, "max": 1080},
-                "calib_roi_w": {"type": "int", "default": -1, "min": -1, "max": 1920},
-                "calib_roi_h": {"type": "int", "default": -1, "min": -1, "max": 1080}
+                "calib_roi_x": {"type": "int", "default": 200, "min": -1, "max": 1920},
+                "calib_roi_y": {"type": "int", "default": 150, "min": -1, "max": 1080},
+                "calib_roi_w": {"type": "int", "default": 240, "min": -1, "max": 1920},
+                "calib_roi_h": {"type": "int", "default": 180, "min": -1, "max": 1080}
             },
             "Visualization": {
                 "draw_thickness": {"type": "int", "default": 2, "min": 1, "max": 10},

--- a/scripts/line_detector_gui.py
+++ b/scripts/line_detector_gui.py
@@ -157,7 +157,7 @@ class LineDetectorParameterGUI:
             "Pre-processing": {
                 "blur_ksize": {"type": "int", "default": 5, "min": 1, "max": 21, "step": 2},
                 "blur_sigma": {"type": "double", "default": 1.5, "min": 0.1, "max": 5.0},
-                "downscale": {"type": "double", "default": 1.0, "min": 0.1, "max": 2.0},
+
                 "roi_x": {"type": "int", "default": -1, "min": -1, "max": 1920},
                 "roi_y": {"type": "int", "default": -1, "min": -1, "max": 1080},
                 "roi_w": {"type": "int", "default": -1, "min": -1, "max": 1920},

--- a/scripts/line_detector_gui.py
+++ b/scripts/line_detector_gui.py
@@ -192,19 +192,6 @@ class LineDetectorParameterGUI:
                 "hsv_dilate_kernel": {"type": "int", "default": 3, "min": 1, "max": 21, "step": 2},
                 "hsv_dilate_iter": {"type": "int", "default": 1, "min": 0, "max": 10}
             },
-            "Edge Closing": {
-                "use_edge_close": {"type": "bool", "default": True},
-                "edge_close_kernel": {"type": "int", "default": 3, "min": 1, "max": 21, "step": 2},
-                "edge_close_iter": {"type": "int", "default": 1, "min": 0, "max": 10}
-            },
-            "Temporal Smoothing": {
-                "enable_temporal_smoothing": {"type": "bool", "default": True},
-                "ema_alpha": {"type": "double", "default": 0.5, "min": 0.0, "max": 1.0},
-                "match_max_px": {"type": "int", "default": 20, "min": 1, "max": 100},
-                "match_max_angle_deg": {"type": "double", "default": 10.0, "min": 0.0, "max": 180.0},
-                "min_age_to_publish": {"type": "int", "default": 2, "min": 0, "max": 10},
-                "max_missed": {"type": "int", "default": 3, "min": 0, "max": 10}
-            },
             "Calibration": {
                 "camera_height_meters": {"type": "double", "default": 0.2, "min": 0.05, "max": 1.0},
                 "landmark_distance_meters": {"type": "double", "default": 0.59, "min": 0.1, "max": 2.0},

--- a/src/etrobo_line_detector.cpp
+++ b/src/etrobo_line_detector.cpp
@@ -107,9 +107,9 @@ class LineDetectorNode : public rclcpp::Node {
     calib_timeout_sec_ =
         this->declare_parameter<double>("calib_timeout_sec", 60.0);
     calib_roi_ = this->declare_parameter<std::vector<int64_t>>(
-        "calib_roi", std::vector<int64_t>{-1, -1, -1, -1});
-    calib_hsv_s_max_ = this->declare_parameter<int>("calib_hsv_s_max", 60);
-    calib_hsv_v_min_ = this->declare_parameter<int>("calib_hsv_v_min", 80);
+        "calib_roi", std::vector<int64_t>{200, 150, 240, 180});
+    calib_hsv_s_max_ = this->declare_parameter<int>("calib_hsv_s_max", 16);
+    calib_hsv_v_min_ = this->declare_parameter<int>("calib_hsv_v_min", 100);
     calib_hsv_v_max_ = this->declare_parameter<int>("calib_hsv_v_max", 168);
     calib_min_area_ = this->declare_parameter<int>("calib_min_area", 80);
     calib_min_major_px_ = this->declare_parameter<int>("calib_min_major_px", 8);

--- a/src/etrobo_line_detector.cpp
+++ b/src/etrobo_line_detector.cpp
@@ -45,7 +45,6 @@ class LineDetectorNode : public rclcpp::Node {
     publish_image_ =
         this->declare_parameter<bool>("publish_image_with_lines", false);
 
-    grayscale_ = this->declare_parameter<bool>("grayscale", true);
     use_hsv_mask_ = this->declare_parameter<bool>("use_hsv_mask", true);
     blur_ksize_ = this->declare_parameter<int>("blur_ksize", 5);
     blur_sigma_ = this->declare_parameter<double>("blur_sigma", 1.5);
@@ -188,22 +187,15 @@ class LineDetectorNode : public rclcpp::Node {
       work = tmp;
     }
 
-    // Grayscale and blur
+    // Convert to grayscale for Canny edge detection
     cv::Mat gray;
-    if (grayscale_) {
-      if (work.channels() == 3) {
-        cv::cvtColor(work, gray, cv::COLOR_BGR2GRAY);
-      } else {
-        gray = work;
-      }
+    if (work.channels() == 3) {
+      cv::cvtColor(work, gray, cv::COLOR_BGR2GRAY);
     } else {
-      // operate on one channel anyway for Canny
-      if (work.channels() == 3) {
-        cv::cvtColor(work, gray, cv::COLOR_BGR2GRAY);
-      } else {
-        gray = work;
-      }
+      gray = work;
     }
+
+    // Apply blur if enabled
     if (blur_ksize_ > 1) {
       cv::GaussianBlur(gray, gray, cv::Size(blur_ksize_, blur_ksize_),
                        blur_sigma_);
@@ -528,9 +520,7 @@ class LineDetectorNode : public rclcpp::Node {
     for (const auto &p : params) {
       const auto &name = p.get_name();
       try {
-        if (name == "grayscale")
-          grayscale_ = p.as_bool();
-        else if (name == "use_hsv_mask")
+        if (name == "use_hsv_mask")
           use_hsv_mask_ = p.as_bool();
         else if (name == "blur_ksize")
           blur_ksize_ = p.as_int();
@@ -1086,7 +1076,6 @@ class LineDetectorNode : public rclcpp::Node {
   std::string image_topic_;
   std::string camera_info_topic_;
   bool publish_image_{};
-  bool grayscale_{};
   bool use_hsv_mask_{};
   int blur_ksize_{};
   double blur_sigma_{};

--- a/src/etrobo_line_detector.cpp
+++ b/src/etrobo_line_detector.cpp
@@ -109,8 +109,8 @@ class LineDetectorNode : public rclcpp::Node {
     calib_roi_ = this->declare_parameter<std::vector<int64_t>>(
         "calib_roi", std::vector<int64_t>{-1, -1, -1, -1});
     calib_hsv_s_max_ = this->declare_parameter<int>("calib_hsv_s_max", 60);
-    calib_hsv_v_min_ = this->declare_parameter<int>("calib_hsv_v_min", 60);
-    calib_hsv_v_max_ = this->declare_parameter<int>("calib_hsv_v_max", 200);
+    calib_hsv_v_min_ = this->declare_parameter<int>("calib_hsv_v_min", 80);
+    calib_hsv_v_max_ = this->declare_parameter<int>("calib_hsv_v_max", 168);
     calib_min_area_ = this->declare_parameter<int>("calib_min_area", 80);
     calib_min_major_px_ = this->declare_parameter<int>("calib_min_major_px", 8);
     calib_max_major_ratio_ =

--- a/src/etrobo_line_detector.cpp
+++ b/src/etrobo_line_detector.cpp
@@ -79,10 +79,10 @@ class LineDetectorNode : public rclcpp::Node {
     hsv_lower_s_ = this->declare_parameter<int>("hsv_lower_s", 0);
     hsv_lower_v_ = this->declare_parameter<int>("hsv_lower_v", 0);
     hsv_upper_h_ = this->declare_parameter<int>("hsv_upper_h", 180);
-    hsv_upper_s_ = this->declare_parameter<int>("hsv_upper_s", 120);
-    hsv_upper_v_ = this->declare_parameter<int>("hsv_upper_v", 150);
+    hsv_upper_s_ = this->declare_parameter<int>("hsv_upper_s", 40);
+    hsv_upper_v_ = this->declare_parameter<int>("hsv_upper_v", 148);
     hsv_dilate_kernel_ = this->declare_parameter<int>("hsv_dilate_kernel", 3);
-    hsv_dilate_iter_ = this->declare_parameter<int>("hsv_dilate_iter", 1);
+    hsv_dilate_iter_ = this->declare_parameter<int>("hsv_dilate_iter", 2);
 
     // Calibration parameters
     camera_height_m_ =


### PR DESCRIPTION
Requirement

<img width="396" height="321" alt="Screenshot from 2025-08-09 19-12-42" src="https://github.com/user-attachments/assets/1c955cde-123c-4eb4-95e2-0e5a5d0a773c" />

スタート直後にあるグレーの円までの距離はわかっています。ライン検出の結果を使って、カメラの取り付け俯角を測定するコードを作成したいです。

前提：
- スタート直後にあるグレーの円までの距離[m]は既知
- カメラの取り付け高さは既知で、走行体前方を向いている
- カメラ行列はcamera_infoトピックから取得できる

やりたいこと:
- etrobo_line_detectorノードは2状態をもち、起動直後はカメラ俯角を測定する状態となる。 俯角の測定が完了すると走行準備完了状態となる。
- 俯角測定モードではカメラ画像からラインを検出して、グレーの円までの距離から俯角を測定する。このとき enable_temporal_smoothingはtrueとする。またline segmentsトピックはまだ出力しない。
- 走行準備完了状態では、enable_temporal_smoothingをfalseに切り替えてline segmentsトピックを出力します。
- image_with_linesは、後ほど要件はまとめますが、走行体がラインからの距離や、ラインの方位角、灰色円などランドマークまでの距離、方位角や、さらにコースの2次元平面へのカメラ画像の射影などを表示してもらおうと思っています。

パラメータ名とデフォルト値()は次のようにしてください
- camera_height_meters (0.2m)
- landmark_distance_meters (0.7m)
- calib_timeout_sec (60s)

Change Summary
- Add two-state flow: CalibratePitch -> Ready
- In CalibratePitch: enable temporal smoothing, detect gray circle, estimate pitch; do not publish lines
- Transition to Ready: disable temporal smoothing and publish lines/markers
- Subscribe to CameraInfo and use intrinsics (fx, fy, cx, cy)
- Parameters added: camera_height_meters (0.2), landmark_distance_meters (0.7), calib_timeout_sec (60.0), camera_info_topic
- Docs updated (README, DESIGN) to explain calibration and parameters

Testing
- Build: Starting >>> etrobo_line_detector

Summary: 0 packages finished [0.69s]
  1 package failed: etrobo_line_detector
  1 package had stderr output: etrobo_line_detector
- Run: 
- Provide camera image and CameraInfo; observe INFO logs: calibration starts, collects detections, estimates pitch (deg/rad), then transitions to Ready
- During calibration:  topic is not published; after transition:  and  publish; smoothing disabled
- Timeout behavior: if no circle is found within calib_timeout_sec, node proceeds with 0 rad pitch and starts publishing